### PR TITLE
Skip installing optional transient front-end dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
               <goal>npm</goal>
             </goals>
             <configuration>
-              <arguments>install</arguments>
+              <arguments>install --no-optional</arguments>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
Add --no-optional to the npm install command line to skip compiling/installing optional transient front-end dependencies. Significantly reduces build time, and avoids warnings when the needed build dependencies (e.g. python, C compiler) aren't installed.