### PR TITLE
Fix up Continuous Deployment Stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,7 @@ deploy:
     script: src/scripts/deploy-test.sh
     on:
       branch: master
+  - provider: script
+    script: src/scripts/deploy-prod.sh
+    on:
+      tags: true

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
   <artifactId>awesomeagile</artifactId>
   <version>1.0-SNAPSHOT</version>
   <name>Awesome Agile</name>
+  <description>An Agile Coaching Resource</description>
   <inceptionYear>2015</inceptionYear>
   <organization>
     <name>Mark Warren, Phillip Heller, Matt Kubej, Linghong Chen, Stanislav Belov, Qanit Al</name>
@@ -274,7 +275,7 @@
         <version>0.3.5</version>
         <configuration>
           <serverId>docker-hub</serverId>
-          <imageName>awesomeagile/${project.artifactId}:latest</imageName>
+          <imageName>awesomeagile/${project.artifactId}:${docker.tag}</imageName>
           <dockerDirectory>${project.basedir}/src/docker/awesomeagile</dockerDirectory>
           <resources>
             <resource>

--- a/src/docker/awesomeagile/Dockerfile
+++ b/src/docker/awesomeagile/Dockerfile
@@ -1,8 +1,8 @@
 FROM awesomeagile/tomcat-jar:latest
 
 RUN useradd -r awesomeagile
- 
-EXPOSE 8888
+
+EXPOSE 8887 8888
 
 ADD awesomeagile.jar /awesomeagile.jar
 

--- a/src/main/java/org/awesomeagile/webapp/config/SslRedirectConfig.java
+++ b/src/main/java/org/awesomeagile/webapp/config/SslRedirectConfig.java
@@ -43,7 +43,6 @@ import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletCon
 import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -52,12 +51,6 @@ public class SslRedirectConfig {
 
     @Value("${ssl.redirect.port:8887}")
     private Integer sslRedirectPort;
-
-    @Bean
-    public static PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
-        PropertySourcesPlaceholderConfigurer c = new PropertySourcesPlaceholderConfigurer();
-        return c;
-    }
 
 	@Bean
 	public TomcatEmbeddedServletContainerFactory tomcatFactory() {

--- a/src/main/java/org/awesomeagile/webapp/config/SslRedirectConfig.java
+++ b/src/main/java/org/awesomeagile/webapp/config/SslRedirectConfig.java
@@ -1,0 +1,98 @@
+package org.awesomeagile.webapp.config;
+
+/*
+ * ================================================================================================
+ * Awesome Agile
+ * %%
+ * Copyright (C) 2015 Mark Warren, Phillip Heller, Matt Kubej, Linghong Chen, Stanislav Belov, Qanit Al
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------------------------
+ */
+
+import org.apache.catalina.*;
+import org.apache.catalina.connector.Connector;
+import org.apache.catalina.core.StandardContext;
+import org.apache.catalina.core.StandardEngine;
+import org.apache.catalina.core.StandardHost;
+import org.apache.catalina.core.StandardService;
+import org.apache.catalina.startup.Tomcat;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer;
+import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class SslRedirectConfig {
+
+	@Value("${ssl.redirect.port:8887}")
+	private Integer sslRedirectPort;
+
+	@Bean
+	public TomcatEmbeddedServletContainerFactory tomcatFactory() {
+		return new TomcatEmbeddedServletContainerFactory() {
+			@Override
+			protected TomcatEmbeddedServletContainer getTomcatEmbeddedServletContainer(
+					Tomcat tomcat) {
+				Server server = tomcat.getServer();
+
+				Service service = new StandardService();
+				service.setName("ssl-redirect-service");
+				Connector connector = new Connector("org.apache.coyote.http11.Http11NioProtocol");
+				connector.setPort(sslRedirectPort);
+				service.addConnector(connector);
+				server.addService(service);
+
+				Engine engine = new StandardEngine();
+				service.setContainer(engine);
+
+				Host host = new StandardHost();
+				host.setName("ssl-redirect-host");
+				engine.addChild(host);
+				engine.setDefaultHost(host.getName());
+
+				Context context = new StandardContext();
+				context.addLifecycleListener(new Tomcat.FixContextListener());
+				context.setName("ssl-redirect-context");
+				context.setPath("");
+				host.addChild(context);
+
+				Wrapper wrapper = context.createWrapper();
+				wrapper.setServlet(new HttpServlet() {
+					@Override
+					public void service(HttpServletRequest req, HttpServletResponse res)
+							throws ServletException, IOException {
+						UriComponentsBuilder b = UriComponentsBuilder.fromHttpUrl(req.getRequestURL().toString());
+						b.scheme("https");
+						b.port(null);
+						res.sendRedirect(b.toUriString());
+					}
+				});
+				wrapper.setName("ssl-redirect-servlet");
+				context.addChild(wrapper);
+				context.addServletMapping("/", wrapper.getName());
+
+				return super.getTomcatEmbeddedServletContainer(tomcat);
+			}
+		};
+	}
+
+}

--- a/src/main/java/org/awesomeagile/webapp/config/SslRedirectConfig.java
+++ b/src/main/java/org/awesomeagile/webapp/config/SslRedirectConfig.java
@@ -1,5 +1,12 @@
 package org.awesomeagile.webapp.config;
 
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 /*
  * ================================================================================================
  * Awesome Agile
@@ -19,8 +26,12 @@ package org.awesomeagile.webapp.config;
  * limitations under the License.
  * ------------------------------------------------------------------------------------------------
  */
-
-import org.apache.catalina.*;
+import org.apache.catalina.Context;
+import org.apache.catalina.Engine;
+import org.apache.catalina.Host;
+import org.apache.catalina.Server;
+import org.apache.catalina.Service;
+import org.apache.catalina.Wrapper;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.core.StandardContext;
 import org.apache.catalina.core.StandardEngine;
@@ -31,20 +42,22 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer;
 import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
 import org.springframework.context.annotation.Bean;
-import org.springframework.stereotype.Component;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-
-@Component
+@Configuration
 public class SslRedirectConfig {
 
-	@Value("${ssl.redirect.port:8887}")
-	private Integer sslRedirectPort;
+    @Value("${ssl.redirect.port:8887}")
+    private Integer sslRedirectPort;
+
+    @Bean
+    public static PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
+        PropertySourcesPlaceholderConfigurer c = new PropertySourcesPlaceholderConfigurer();
+        return c;
+    }
 
 	@Bean
 	public TomcatEmbeddedServletContainerFactory tomcatFactory() {
@@ -80,7 +93,8 @@ public class SslRedirectConfig {
 					@Override
 					public void service(HttpServletRequest req, HttpServletResponse res)
 							throws ServletException, IOException {
-						UriComponentsBuilder b = UriComponentsBuilder.fromHttpUrl(req.getRequestURL().toString());
+					    ServletServerHttpRequest r = new ServletServerHttpRequest(req);
+					    UriComponentsBuilder b = UriComponentsBuilder.fromHttpRequest(r);
 						b.scheme("https");
 						b.port(null);
 						res.sendRedirect(b.toUriString());

--- a/src/scripts/deploy-prod.sh
+++ b/src/scripts/deploy-prod.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Get tag from HEAD
+
+TAG=`git describe --exact-match`
+if [ $? -eq 0 ]; then
+  src/scripts/deploy.sh PROD "$TAG"
+else
+  echo "Error, no tag on HEAD!"
+fi

--- a/src/scripts/deploy-test.sh
+++ b/src/scripts/deploy-test.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-src/scripts/deploy.sh TEST
+src/scripts/deploy.sh TEST latest

--- a/src/scripts/deploy.sh
+++ b/src/scripts/deploy.sh
@@ -1,37 +1,44 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
 
 # set DOCKER_HUB_USERNAME, DOCKER_HUB_PASSWORD, and DOCKER_HUB_EMAIL
 
+error() {
+  echo "======== Deployment Error"
+}
+trap error ERR
+
+if [ $# -ne 2 ]; then
+  echo "usage: deploy.sh <environment> <tag>"
+  exit 1
+fi
+
 echo "======== Deploying awesomeagile to $1 environment"
 echo "======== Installing the AWS CLI"
-pip install --user awscli \
-&& \
-export PATH=$PATH:$HOME/.local/bin \
-&& \
+pip install --user awscli
+export PATH=$PATH:$HOME/.local/bin
+
 echo "======== Packaging"
-mvn package -DskipTests \
-&& \
-echo "======== Building and pushing Docker Image" \
-&& \
+mvn package -DskipTests
+
+echo "======== Building and pushing Docker Image"
 mvn \
   -DskipTests \
   --settings src/scripts/maven_settings.xml \
-  docker:build docker:push \
-&& \
-echo "======== Revising the AWS ECS Task Definition" \
-&& \
+  -Ddocker.tag="$2" \
+  docker:build docker:push
+
+echo "======== Revising the AWS ECS Task Definition"
 aws ecs register-task-definition \
-  --cli-input-json "`src/scripts/get-task-definition.sh $1`" \
-  >> /dev/null \
-&& \
-echo "======== Updating the AWS ECS Service to use the latest Task Definition" \
-&& \
+  --cli-input-json "`src/scripts/get-task-definition.sh $1 $2`" \
+  >> /dev/null
+
+echo "======== Updating the AWS ECS Service to use the latest Task Definition"
 aws ecs update-service \
-  --cluster $1\
-  --service awesomeagile \
-  --task-definition awesomeagile \
-  >> /dev/null \
-&& \
-echo "======== Deployment complete" \
-|| \
-echo "======== Deployment Error"
+  --cluster "$1" \
+  --service "awesomeagile-$1" \
+  --task-definition "awesomeagile-$1" \
+  >> /dev/null
+
+echo "======== Deployment complete"

--- a/src/scripts/get-task-definition.sh
+++ b/src/scripts/get-task-definition.sh
@@ -17,6 +17,11 @@ $(cat << EOF | sed s/%%ENV%%/$1/g
             "memory": 512,
             "portMappings": [
                 {
+                    "containerPort": 8887,
+                    "hostPort": 8887,
+                    "protocol": "tcp"
+                },
+                {
                     "containerPort": 8888,
                     "hostPort": 8888,
                     "protocol": "tcp"

--- a/src/scripts/get-task-definition.sh
+++ b/src/scripts/get-task-definition.sh
@@ -1,23 +1,18 @@
 #!/bin/sh
 
-#if [ "$#" -eq 1 ]; then
-#eval "cat <<EOF
-#$(cat taskdef.json | sed s/%%ENV%%/$1/)
-#EOF
-#" 2> /dev/null
-#else
-#  echo "usage: get-task-definition.sh <deployment environment>"
-#fi
+if [ $# -ne 2 ]; then
+  echo "usage: get-task-definition.sh <deployment environment> <image tag>"
+  exit 1
+fi
 
-if [ "$#" -eq 1 ]; then
 eval "cat <<EOF
-$(cat << EOF | sed s/%%ENV%%/$1/
+$(cat << EOF | sed s/%%ENV%%/$1/g
 {
-    "family": "awesomeagile", 
+    "family": "awesomeagile-%%ENV%%",
     "containerDefinitions": [
         {
             "name": "awesomeagile",
-            "image": "awesomeagile/awesomeagile:latest", 
+            "image": "awesomeagile/awesomeagile:$2",
             "cpu": 0,
             "memory": 512,
             "portMappings": [
@@ -58,6 +53,3 @@ EOF
 )
 EOF
 " 2> /dev/null
-else
-  echo "usage: get-task-definition.sh <deployment environment>"
-fi

--- a/src/test/java/org/awesomeagile/PropertySupportConfig.java
+++ b/src/test/java/org/awesomeagile/PropertySupportConfig.java
@@ -1,0 +1,34 @@
+package org.awesomeagile;
+
+/*
+ * ================================================================================================
+ * Awesome Agile
+ * %%
+ * Copyright (C) 2015 Mark Warren, Phillip Heller, Matt Kubej, Linghong Chen, Stanislav Belov, Qanit Al
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------------------------
+ */
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+
+@Configuration
+public class PropertySupportConfig {
+    @Bean
+    public static PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
+        PropertySourcesPlaceholderConfigurer c = new PropertySourcesPlaceholderConfigurer();
+        return c;
+    }
+}

--- a/src/test/java/org/awesomeagile/webapp/config/SslRedirectConfigTest.java
+++ b/src/test/java/org/awesomeagile/webapp/config/SslRedirectConfigTest.java
@@ -26,6 +26,7 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
+import org.awesomeagile.PropertySupportConfig;
 import org.glassfish.jersey.client.ClientProperties;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,7 +39,8 @@ import org.springframework.test.context.web.WebAppConfiguration;
 import com.google.common.net.HttpHeaders;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(SslRedirectConfig.class)
+@SpringApplicationConfiguration(classes = { SslRedirectConfig.class,
+        PropertySupportConfig.class })
 @WebAppConfiguration
 @IntegrationTest
 public class SslRedirectConfigTest {

--- a/src/test/java/org/awesomeagile/webapp/config/SslRedirectConfigTest.java
+++ b/src/test/java/org/awesomeagile/webapp/config/SslRedirectConfigTest.java
@@ -1,0 +1,72 @@
+package org.awesomeagile.webapp.config;
+
+/*
+ * ================================================================================================
+ * Awesome Agile
+ * %%
+ * Copyright (C) 2015 Mark Warren, Phillip Heller, Matt Kubej, Linghong Chen, Stanislav Belov, Qanit Al
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------------------------
+ */
+import static org.junit.Assert.assertEquals;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.glassfish.jersey.client.ClientProperties;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import com.google.common.net.HttpHeaders;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(SslRedirectConfig.class)
+@WebAppConfiguration
+@IntegrationTest
+public class SslRedirectConfigTest {
+    private Client client;
+    private WebTarget target;
+    private Response r;
+
+    @Before
+    public void setup() {
+        client = ClientBuilder.newClient();
+        client.property(ClientProperties.FOLLOW_REDIRECTS, false);
+    }
+
+    @Test
+    public void testBasic() {
+        target = client.target("http://localhost:8887");
+        r = target.request().get();
+        assertEquals(302, r.getStatus());
+        assertEquals("https://localhost/",
+                r.getHeaderString(HttpHeaders.LOCATION));
+    }
+
+    @Test
+    public void testComplex() {
+        target = client.target("http://localhost:8887/foo/bar?baz=qux&qux=fnord");
+        r = target.request().get();
+        assertEquals(302, r.getStatus());
+        assertEquals("https://localhost/foo/bar?baz=qux&qux=fnord",
+                r.getHeaderString(HttpHeaders.LOCATION));
+    }
+}


### PR DESCRIPTION
Needed to do a number of things.  Quick summary:

- AWS ELB has 2 listeners (80 and 443).  They were configured to go to NGINX and the Tomcat (running the AwesomeAgile jar), respectively.  However, the ELB has but one health check which could check only one of the two services.  Whichever one it couldn't check, it would mark as down and remove from the load balancer, stop the container and try to restart.  (Hence the ~ 3300 pulls of the image from Dockerhub).

- This is fixed by eliminating the NGINX container and adding a 2nd servlet to the AwesomeAgile jar that serves the same purpose:  redirect HTTP GETs to HTTPS.  This simplifies the AWS ECS configuration a bit, and makes it easier to scale the app in the future, too.

- The remaining changes are to just shore up the nomenclature used for the various pieces in the continuous deployment chain so that there is less confusion.

The end result of this work once merged is that:

  -- Merges to master should kick off a CI test, then deployment to https://test.awesomeagile.org
  -- Tags of the repo (i.e., "v1.0.0") will kick off a deployment of the related commit to https://www.awesomeagile.org.